### PR TITLE
Add gr-gfdm and XFDMSync

### DIFF
--- a/XFDMSync.lwr
+++ b/XFDMSync.lwr
@@ -1,0 +1,31 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+inherit: cmake
+depends:
+- python
+- gnuradio
+source: git+https://github.com/jdemel/XFDMSync.git
+gitbranch: master
+gitargs: --recursive
+vars:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs "
+configure: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix $config_opt
+

--- a/cython.lwr
+++ b/cython.lwr
@@ -1,0 +1,27 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: cmake
+depends:
+- python
+- numpy
+inherit: distutils
+satisfy:
+  deb: cython >= 3.0
+source: git+https://github.com/cython/cython.git

--- a/gr-gfdm.lwr
+++ b/gr-gfdm.lwr
@@ -1,0 +1,35 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: common
+inherit: cmake
+depends:
+- gnuradio
+- python
+- cython
+- scipy
+- scikit-commpy
+source: git+https://github.com/jdemel/gr-gfdm.git
+gitbranch: master
+gitargs: --recursive
+vars:
+  config_opt: " -DENABLE_DOXYGEN=$builddocs "
+configure_static: cmake .. -DCMAKE_BUILD_TYPE=$cmakebuildtype -DCMAKE_INSTALL_PREFIX=$prefix $config_opt
+install:
+    make install

--- a/scikit-commpy.lwr
+++ b/scikit-commpy.lwr
@@ -1,0 +1,31 @@
+#
+# This file is part of PyBOMBS
+#
+# PyBOMBS is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+#
+# PyBOMBS is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyBOMBS; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street,
+# Boston, MA 02110-1301, USA.
+#
+
+category: baseline
+inherit: distutils
+depends:
+- python
+- scipy
+- numpy
+#- commpy
+satisfy:
+  pip: scikit-commpy >= 0.3
+#  deb: scikit-commpy >= 0.3
+source: wget -r https://pypi.org/project/scikit-commpy/#files
+


### PR DESCRIPTION
These proposed files contain an installation routine for files needed for a gnuradio project. This way the recipes should be installed by default. So it's not neccessary anymore to install them manually afterwards.